### PR TITLE
RH - fixing setup.sh to point to the Fractal repo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 base_url() {
   # echos string prefixed with base url
-  echo "https://raw.githubusercontent.com/liamy/rig_setup/master/$1"
+  echo "https://raw.githubusercontent.com/fractaltechnologylabs/provisioning/master/$1"
 }
 
 installHidden() {


### PR DESCRIPTION
Check out my pull request!  It repoints the setup.sh script from liamy/rig-setup to fractaltechnologylabs/provisioning